### PR TITLE
Updating logstash pipeline create and update

### DIFF
--- a/_examples/sample.go
+++ b/_examples/sample.go
@@ -256,14 +256,14 @@ func main() {
 			"id":   "test",
 		},
 	}
-	resp, err = client.API.KibanaSavedObject.Export(nil, request, true, "default")
-	if err != nil {
-		log.Fatalf("Error exporting index pattern: %s", err)
+	response, error := client.API.KibanaSavedObject.Export(nil, request, true, "default")
+	if error != nil {
+		log.Fatalf("Error exporting index pattern: %s", error)
 	}
-	log.Println(resp)
+	log.Println(response)
 
 	// import index pattern in default user space
-	b, err = json.Marshal(resp)
+	b, err = json.Marshal(response)
 	if err != nil {
 		log.Fatalf("Error converting struct to json")
 	}

--- a/kbapi/api.kibana_logstash_pipeline.go
+++ b/kbapi/api.kibana_logstash_pipeline.go
@@ -21,6 +21,13 @@ type LogstashPipeline struct {
 	Username    string                 `json:"username,omitempty"`
 }
 
+type LogstashPipelineRequest struct {
+	Description string                 `json:"description,omitempty"`
+	Pipeline    string                 `json:"pipeline,omitempty"`
+	Settings    map[string]interface{} `json:"settings,omitempty"`
+	Username    string                 `json:"username,omitempty"`
+}
+
 // LogstashPipelinesList is the logstash pipeline list result when get the list
 type LogstashPipelinesList struct {
 	Pipelines LogstashPipelines `json:"pipelines"`
@@ -114,7 +121,13 @@ func newKibanaLogstashPipelineCreateOrUpdateFunc(c *resty.Client) KibanaLogstash
 
 		log.Debug("LogstashPipeline: ", logstashPipeline)
 
-		jsonData, err := json.Marshal(logstashPipeline)
+		logstashPipelineRequest := &LogstashPipelineRequest{
+			Description: logstashPipeline.Description,
+			Pipeline:    logstashPipeline.Pipeline,
+			Settings:    logstashPipeline.Settings,
+		}
+
+		jsonData, err := json.Marshal(logstashPipelineRequest)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Logstash Create/Update api does not allow `request [body.id]` option when creating/updating a pipeline.

Creating a new structure logstash pipeline request to address this issue.


Fixing the test in example

## Testing done

Have passed all the tests present in the repository.