### PR TITLE
Add support for API keys

### DIFF
--- a/kibana.go
+++ b/kibana.go
@@ -12,6 +12,7 @@ type Config struct {
 	Address          string
 	Username         string
 	Password         string
+	ApiKey           string
 	DisableVerifySSL bool
 	CAs              []string
 }
@@ -35,9 +36,16 @@ func NewClient(cfg Config) (*Client, error) {
 
 	restyClient := resty.New().
 		SetBaseURL(cfg.Address).
-		SetBasicAuth(cfg.Username, cfg.Password).
 		SetHeader("kbn-xsrf", "true").
 		SetHeader("Content-Type", "application/json")
+
+	if cfg.ApiKey != "" {
+		restyClient = restyClient.
+			SetAuthScheme("ApiKey").
+			SetAuthToken(cfg.ApiKey)
+	} else {
+		restyClient = restyClient.SetBasicAuth(cfg.Username, cfg.Password)
+	}
 
 	for _, path := range cfg.CAs {
 		restyClient.SetRootCertificate(path)

--- a/kibana_test.go
+++ b/kibana_test.go
@@ -44,10 +44,9 @@ func (s *KBTestSuite) TestNewClient() {
 
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), client)
-	assert.NotNil(s.T(), client.Client.AuthScheme, "Basic")
-	assert.Equal(s.T(), client.Client.UserInfo.Username, "elastic")
-	assert.Equal(s.T(), client.Client.UserInfo.Password, "changeme")
-
+	assert.NotNil(s.T(), "Basic", client.Client.AuthScheme)
+	assert.Equal(s.T(), "elastic", client.Client.UserInfo.Username)
+	assert.Equal(s.T(), "changeme", client.Client.UserInfo.Password)
 }
 
 func (s *KBTestSuite) TestNewAPIKeyClient() {
@@ -63,8 +62,8 @@ func (s *KBTestSuite) TestNewAPIKeyClient() {
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), client)
 
-	assert.Equal(s.T(), client.Client.AuthScheme, "ApiKey")
-	assert.Equal(s.T(), client.Client.Token, "foo")
+	assert.Equal(s.T(), "ApiKey", client.Client.AuthScheme)
+	assert.Equal(s.T(), "foo", client.Client.Token, "foo")
 
 }
 
@@ -75,4 +74,8 @@ func (s *KBTestSuite) TestNewDefaultClient() {
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), client)
 
+	assert.NotNil(s.T(), client.Client.AuthScheme, "Basic")
+	assert.Equal(s.T(), client.Client.UserInfo.Username, "")
+	assert.Equal(s.T(), client.Client.UserInfo.Password, "")
+	assert.Equal(s.T(), client.Client.Token, "")
 }

--- a/kibana_test.go
+++ b/kibana_test.go
@@ -44,6 +44,27 @@ func (s *KBTestSuite) TestNewClient() {
 
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), client)
+	assert.NotNil(s.T(), client.Client.AuthScheme, "Basic")
+	assert.Equal(s.T(), client.Client.UserInfo.Username, "elastic")
+	assert.Equal(s.T(), client.Client.UserInfo.Password, "changeme")
+
+}
+
+func (s *KBTestSuite) TestNewAPIKeyClient() {
+
+	cfg := Config{
+		Address:          "http://127.0.0.1:5601",
+		ApiKey:           "foo",
+		DisableVerifySSL: true,
+	}
+
+	client, err := NewClient(cfg)
+
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), client)
+
+	assert.Equal(s.T(), client.Client.AuthScheme, "ApiKey")
+	assert.Equal(s.T(), client.Client.Token, "foo")
 
 }
 


### PR DESCRIPTION
* Add support for setting API keys instead of basic auth [per the documentation](https://www.elastic.co/guide/en/kibana/current/api-keys.html).
* Added basic instantiation test for API keys and expanded existing tests slightly
* Please note: `go` is not my first language ;)