### PR TITLE
Add support for Data View API

### DIFF
--- a/kbapi/api._.go
+++ b/kbapi/api._.go
@@ -8,6 +8,7 @@ import (
 type API struct {
 	KibanaSpaces           *KibanaSpacesAPI
 	KibanaRoleManagement   *KibanaRoleManagementAPI
+	KibanaDataViews        *KibanaDataViewsAPI
 	KibanaDashboard        *KibanaDashboardAPI
 	KibanaSavedObject      *KibanaSavedObjectAPI
 	KibanaStatus           *KibanaStatusAPI
@@ -31,6 +32,15 @@ type KibanaRoleManagementAPI struct {
 	List           KibanaRoleManagementList
 	CreateOrUpdate KibanaRoleManagementCreateOrUpdate
 	Delete         KibanaRoleManagementDelete
+}
+
+// KibanaDataViewsAPI handle the DataViews API
+type KibanaDataViewsAPI struct {
+	Get    KibanaDataViewGet
+	List   KibanaDataViewList
+	Create KibanaDataViewCreate
+	Delete KibanaDataViewDelete
+	Update KibanaDataViewUpdate
 }
 
 // KibanaDashboardAPI handle the dashboard API
@@ -84,6 +94,13 @@ func New(c *resty.Client) *API {
 			List:           newKibanaRoleManagementListFunc(c),
 			CreateOrUpdate: newKibanaRoleManagementCreateOrUpdateFunc(c),
 			Delete:         newKibanaRoleManagementDeleteFunc(c),
+		},
+		KibanaDataViews: &KibanaDataViewsAPI{
+			Get:    newKibanaDataViewGetFunc(c),
+			List:   newKibanaDataViewListFunc(c),
+			Create: newKibanaDataViewCreateFunc(c),
+			Update: newKibanaDataViewUpdateFunc(c),
+			Delete: newKibanaDataViewDeleteFunc(c),
 		},
 		KibanaDashboard: &KibanaDashboardAPI{
 			Export: newKibanaDashboardExportFunc(c),

--- a/kbapi/api.kibana_data_view.go
+++ b/kbapi/api.kibana_data_view.go
@@ -1,0 +1,232 @@
+package kbapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/go-resty/resty/v2"
+	log "github.com/sirupsen/logrus"
+)
+
+// DataView is the DataView API object
+type DataView struct {
+	ID           string                 `json:"id,omitempty"`
+	Name         string                 `json:"name"`
+	Title        string                 `json:"title"`
+	Namespaces   []string               `json:"namespaces,omitempty"`
+	AllowNoIndex bool                   `json:"allowNoIndex,omitempty"`
+	TypeMeta     map[string]interface{} `json:"typeMeta,omitempty"`
+}
+
+type dataViewWrapper struct {
+	DataView DataView `json:"data_view"`
+}
+
+// KibanaDataViewGet permit to get data view
+type KibanaDataViewGet func(id string, spaceID string) (*DataView, error)
+
+// KibanaDataViewList permit to get all data views
+type KibanaDataViewList func(spaceID string) ([]DataView, error)
+
+// KibanaDataViewCreate permit to create data view
+type KibanaDataViewCreate func(kibanaDataView *DataView, spaceID string) (*DataView, error)
+
+// KibanaDataViewDelete permit to delete data view
+type KibanaDataViewDelete func(id string, spaceID string) error
+
+// KibanaDataViewUpdate permit to update data view
+type KibanaDataViewUpdate func(kibanaDataView *DataView, spaceID string) (*DataView, error)
+
+// String permit to return KibanaDataView object as JSON string
+func (k *DataView) String() string {
+	j, _ := json.Marshal(k)
+	return string(j)
+}
+
+// newKibanaDataViewGetFunc permit to get the kibana data view with its id
+func newKibanaDataViewGetFunc(c *resty.Client) KibanaDataViewGet {
+	return func(id string, spaceID string) (*DataView, error) {
+
+		if id == "" {
+			return nil, NewAPIError(600, "You must provide kibana data view ID")
+		}
+		log.Debug("ID: ", id)
+
+		path := generatePath("data_view", id, spaceID)
+		resp, err := c.R().Get(path)
+		if err != nil {
+			return nil, err
+		}
+		log.Debug("Response: ", resp)
+		if resp.StatusCode() >= 300 {
+			if resp.StatusCode() == 404 {
+				return nil, nil
+			}
+			return nil, NewAPIError(resp.StatusCode(), resp.Status())
+		}
+
+		dv := &dataViewWrapper{DataView: DataView{}}
+		err = json.Unmarshal(resp.Body(), dv)
+		if err != nil {
+			return nil, err
+		}
+		log.Debug("KibanaDataView: ", dv)
+
+		return &dv.DataView, nil
+	}
+
+}
+
+// newKibanaDataViewListFunc permit to get all Kibana data view
+func newKibanaDataViewListFunc(c *resty.Client) KibanaDataViewList {
+	return func(spaceID string) ([]DataView, error) {
+
+		type dataViews struct {
+			DataViews []DataView `json:"data_view"`
+		}
+
+		path := generatePath("", "", spaceID)
+		resp, err := c.R().Get(path)
+		if err != nil {
+			return []DataView{}, err
+		}
+		log.Debug("Response: ", resp)
+		if resp.StatusCode() >= 300 {
+			return []DataView{}, NewAPIError(resp.StatusCode(), resp.Status())
+		}
+		dataViewsList := dataViews{}
+		err = json.Unmarshal(resp.Body(), &dataViewsList)
+		if err != nil {
+			return []DataView{}, err
+		}
+		log.Debug("DataViews: ", dataViewsList)
+
+		return dataViewsList.DataViews, nil
+	}
+
+}
+
+// newKibanaDataViewCreateFunc permit to create new Kibana data view
+func newKibanaDataViewCreateFunc(c *resty.Client) KibanaDataViewCreate {
+	return func(kibanaDataView *DataView, spaceID string) (*DataView, error) {
+
+		if kibanaDataView == nil {
+			return nil, NewAPIError(600, "You must provide kibana data view object")
+		}
+		log.Debug("KibanaDataView: ", kibanaDataView)
+
+		dv := &dataViewWrapper{DataView: *kibanaDataView}
+
+		jsonData, err := json.Marshal(dv)
+		if err != nil {
+			return nil, err
+		}
+		path := generatePath("data_view", "", spaceID)
+		resp, err := c.R().SetBody(jsonData).Post(path)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Debug("Response: ", string(jsonData))
+		if resp.StatusCode() >= 300 {
+			return nil, NewAPIError(resp.StatusCode(), resp.Status())
+		}
+		dv = &dataViewWrapper{}
+		err = json.Unmarshal(resp.Body(), dv)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Debug("KibanaDataView: ", dv)
+
+		return &dv.DataView, nil
+	}
+
+}
+
+// newKibanaDataViewDeleteFunc permit to delete the kibana data view with its id
+func newKibanaDataViewDeleteFunc(c *resty.Client) KibanaDataViewDelete {
+	return func(id string, spaceID string) error {
+
+		if id == "" {
+			return NewAPIError(600, "You must provide kibana data view ID")
+		}
+
+		log.Debug("ID: ", id)
+
+		path := generatePath("data_view", id, spaceID)
+		resp, err := c.R().Delete(path)
+		if err != nil {
+			return err
+		}
+		log.Debug("Response: ", resp)
+		if resp.StatusCode() >= 300 {
+
+			return NewAPIError(resp.StatusCode(), resp.Status())
+
+		}
+
+		return nil
+	}
+
+}
+
+// newKibanaDataViewUpdateFunc permit to update the Kibana data view
+func newKibanaDataViewUpdateFunc(c *resty.Client) KibanaDataViewUpdate {
+	return func(kibanaDataView *DataView, spaceID string) (*DataView, error) {
+
+		if kibanaDataView == nil {
+			return nil, NewAPIError(600, "You must provide kibana data view object")
+		}
+		log.Debug("KibanaDataView: ", kibanaDataView)
+
+		path := generatePath("data_view", kibanaDataView.ID, spaceID)
+
+		dv := &dataViewWrapper{
+			DataView: *kibanaDataView,
+		}
+		dv.DataView.ID = ""
+
+		jsonData, err := json.Marshal(dv)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.R().SetBody(jsonData).Post(path)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Debug("Response: ", resp)
+		if resp.StatusCode() >= 300 {
+			return nil, NewAPIError(resp.StatusCode(), resp.Status())
+		}
+		dv = &dataViewWrapper{}
+		err = json.Unmarshal(resp.Body(), dv)
+		if err != nil {
+			return nil, err
+		}
+		log.Debug("KibanaDataView: ", dv)
+
+		return &dv.DataView, nil
+	}
+}
+
+// Generate the path for a data view method.
+// resourceType is the resource type being acted upon, `data_view` for CRUD, empty for the List operation
+// id is optional since the Create/List methods do not specify an ID
+// spaceId is optional since an empty value means it's the default space
+func generatePath(resourceType string, id string, spaceId string) string {
+	// Set the correct base path based on whether a space is provided
+	base := "/api/data_views"
+	if spaceId != "" {
+		base = fmt.Sprintf("/s/%s/api/data_views", spaceId)
+	}
+	// Prepend a slash to a non-empty ID
+	if id != "" {
+		id = fmt.Sprintf("/%s", id)
+	}
+	// Prepend a slash to a non-empty resourceType
+	if resourceType != "" {
+		resourceType = fmt.Sprintf("/%s", resourceType)
+	}
+	return fmt.Sprintf("%s%s%s", base, resourceType, id)
+}

--- a/kbapi/api.kibana_data_view_test.go
+++ b/kbapi/api.kibana_data_view_test.go
@@ -1,0 +1,174 @@
+package kbapi
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func (s *KBAPITestSuite) TestKibanaDataView() {
+
+	cases := []struct {
+		description  string
+		resourceType string
+		id           string
+		spaceId      string
+		expected     string
+	}{
+		{
+			description:  "List in default space",
+			resourceType: "",
+			id:           "",
+			spaceId:      "",
+			expected:     "/api/data_views",
+		},
+		{
+			description:  "List in named space",
+			resourceType: "",
+			id:           "",
+			spaceId:      "space1",
+			expected:     "/s/space1/api/data_views",
+		},
+		{
+			description:  "Create in default space",
+			resourceType: "data_view",
+			id:           "",
+			spaceId:      "",
+			expected:     "/api/data_views/data_view",
+		},
+		{
+			description:  "Create in named space",
+			resourceType: "data_view",
+			id:           "",
+			spaceId:      "space1",
+			expected:     "/s/space1/api/data_views/data_view",
+		},
+		{
+			description:  "Get/Update/Delete in default space",
+			resourceType: "data_view",
+			id:           "id123",
+			spaceId:      "",
+			expected:     "/api/data_views/data_view/id123",
+		},
+		{
+			description:  "Get/Update/Delete in named space",
+			resourceType: "data_view",
+			id:           "id123",
+			spaceId:      "space1",
+			expected:     "/s/space1/api/data_views/data_view/id123",
+		},
+	}
+	for _, tt := range cases {
+		s.T().Run(tt.description, func(t *testing.T) {
+			result := generatePath(tt.resourceType, tt.id, tt.spaceId)
+			if result != tt.expected {
+				t.Errorf("expected %s, but got %s", tt.expected, result)
+			}
+		})
+	}
+
+	// Create new data view
+	data := &DataView{
+		ID:    "test-id",
+		Name:  "test-name",
+		Title: "test-title-*",
+	}
+	resp, err := s.API.KibanaDataViews.Create(data, "")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), data.ID, resp.ID)
+	assert.Equal(s.T(), data.Name, resp.Name)
+	assert.Equal(s.T(), data.Title, resp.Title)
+
+	// Create new data view in a space
+	spacedData := &DataView{
+		ID:    "testacc-test-id",
+		Name:  "testacc-test-name",
+		Title: "testacc-test-title-*",
+	}
+	resp, err = s.API.KibanaDataViews.Create(spacedData, "testacc")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), spacedData.ID, resp.ID)
+	assert.Equal(s.T(), spacedData.Name, resp.Name)
+	assert.Equal(s.T(), spacedData.Title, resp.Title)
+
+	// List all data views
+	listResp, err := s.API.KibanaDataViews.List("")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), listResp)
+	found := 0
+	for _, view := range listResp {
+		if view.ID == data.ID {
+			assert.Equal(s.T(), data.Name, view.Name)
+			assert.Equal(s.T(), data.Title, view.Title)
+			found++
+		}
+	}
+	assert.Equal(s.T(), 1, found)
+
+	// List all data views in a space
+	listResp, err = s.API.KibanaDataViews.List("testacc")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), listResp)
+	found = 0
+	for _, view := range listResp {
+		if view.ID == spacedData.ID {
+			assert.Equal(s.T(), spacedData.Name, view.Name)
+			assert.Equal(s.T(), spacedData.Title, view.Title)
+			found++
+		}
+	}
+	assert.Equal(s.T(), 1, found)
+
+	// Get specific data view
+	resp, err = s.API.KibanaDataViews.Get(data.ID, "")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), data.ID, resp.ID)
+
+	// Get specific data view in a space
+	resp, err = s.API.KibanaDataViews.Get(spacedData.ID, "testacc")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), spacedData.ID, resp.ID)
+
+	// Update data view
+	updatedData := &DataView{
+		ID:    data.ID,
+		Name:  "test-name-updated",
+		Title: "test-title-updated-*",
+	}
+	resp, err = s.API.KibanaDataViews.Update(updatedData, "")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), updatedData.ID, resp.ID)
+	assert.Equal(s.T(), updatedData.Name, resp.Name)
+	assert.Equal(s.T(), updatedData.Title, resp.Title)
+
+	// Update data view in a space
+	spacedUpdatedData := &DataView{
+		ID:    spacedData.ID,
+		Name:  "testacc-test-name-updated",
+		Title: "testacc-test-title-updated-*",
+	}
+	resp, err = s.API.KibanaDataViews.Update(spacedUpdatedData, "testacc")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), spacedUpdatedData.ID, resp.ID)
+	assert.Equal(s.T(), spacedUpdatedData.Name, resp.Name)
+	assert.Equal(s.T(), spacedUpdatedData.Title, resp.Title)
+
+	// Delete data view
+	err = s.API.KibanaDataViews.Delete(updatedData.ID, "")
+	assert.NoError(s.T(), err)
+	resp, err = s.API.KibanaDataViews.Get(updatedData.ID, "")
+	assert.NoError(s.T(), err)
+	assert.Nil(s.T(), resp)
+
+	// Delete data view in a space
+	err = s.API.KibanaDataViews.Delete(spacedUpdatedData.ID, "testacc")
+	assert.NoError(s.T(), err)
+	resp, err = s.API.KibanaDataViews.Get(spacedUpdatedData.ID, "testacc")
+	assert.NoError(s.T(), err)
+	assert.Nil(s.T(), resp)
+}


### PR DESCRIPTION
Adds partial support for [Data View](https://www.elastic.co/guide/en/kibana/current/data-views-api.html) API.

Adds the methods:
- KibanaDataViews.Create()
- KibanaDataViews.Delete()
- KibanaDataViews.Get()
- KibanaDataViews.List()
- KibanaDataViews.Update()

They can be created within a space or in the default space.

Does not support getting or setting the space's default data_view, nor metadata, nor runtime fields. Additionally it doesn't support all the optional fields of a data view object such as field attributes, only covering what I'd consider the essential fields, ID, name, title, and spaceID.

I'm submitting this PR because this repository is used by [elastic/terraform-provider-elasticstack](https://github.com/elastic/terraform-provider-elasticstack), and I want a [terraform provider feature](https://github.com/elastic/terraform-provider-elasticstack/issues/75) which I think would benefit from this repository having Data View API support. However I'm not confident with Golang, so I'm happy to receive feedback on this PR and address those comments.